### PR TITLE
chore(ci): auto update protodocs

### DIFF
--- a/.github/workflows/update-protos.yml
+++ b/.github/workflows/update-protos.yml
@@ -15,7 +15,6 @@ jobs:
           fetch-depth: 0
           # Needed for submodules
           submodules: true
-          token: ${{ secrets.PROTOS_GITHUB_TOKEN }}
 
       - name: Pull latest submodule changes
         run: |

--- a/.github/workflows/update-protos.yml
+++ b/.github/workflows/update-protos.yml
@@ -1,0 +1,70 @@
+name: Update protos
+
+on:
+  schedule:
+    - cron: '0 0 * * 1,4' # runs twice a week
+  workflow_dispatch:
+
+jobs:
+  update-protos:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the docs repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Needed for submodules
+          submodules: true
+          token: ${{ secrets.PROTOS_GITHUB_TOKEN }}
+
+      - name: Pull latest submodule changes
+        run: |
+          git submodule update --remote --init
+          # Check if there's any change
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No new commits in submodule. Exiting."
+            exit 0
+          fi
+
+      - uses: pnpm/action-setup@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup protoc-gen-doc
+        run: |
+          sudo apt update
+          sudo apt install -y golang
+          go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@latest
+          export PATH="$PATH:$(go env GOPATH)/bin"
+      
+      - name: Generate proto_workspace.json
+        run: |
+          protoc \
+            --proto_path=./protos \
+            --doc_out=./fixtures \
+            --doc_opt=json,proto_workspace.json \
+            $(find protos/nori -name "*.proto")
+
+      - name: Generate protodocs
+        run: pnpm exec docusaurus generate-proto-docs
+
+      - name: Commit changes
+        run: |
+          git checkout -b update-protos-branch
+          git add .
+          git commit -m "chore: update protos and regenerate docs"
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.PR_GITHUB_TOKEN }}
+          branch: update-protos-branch
+          title: "Update protos and docs"
+          body: "This PR updates the protos submodule to the latest and regenerates the docs."
+          base: main


### PR DESCRIPTION
When a new commit is made in the main branch of `nori-protos`, the GitHub Action will open a Pull Request to update the API reference docs in this repository.

The action will run twice a week to check if there are any new commits in `nori-protos` `main`.